### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/sijit/454fbfe0-ced1-4dbd-8303-89da1dd1c7d4/91ca1625-f83e-4bdd-965d-25cfc4cafa97/_apis/work/boardbadge/1cce4f99-e4e6-477e-a523-8de7f862edc1)](https://dev.azure.com/sijit/454fbfe0-ced1-4dbd-8303-89da1dd1c7d4/_boards/board/t/91ca1625-f83e-4bdd-965d-25cfc4cafa97/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#26090](https://dev.azure.com/sijit/454fbfe0-ced1-4dbd-8303-89da1dd1c7d4/_workitems/edit/26090). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.